### PR TITLE
Fix incorrect obj.send(...) to accessors instead of mutators in persistence methods

### DIFF
--- a/lib/stateflow/persistence/active_record.rb
+++ b/lib/stateflow/persistence/active_record.rb
@@ -14,7 +14,7 @@ module Stateflow
         end
 
         def save_to_persistence(new_state, options)
-          self.send(machine.state_column.to_sym, new_state)
+          self.send("#{machine.state_column}=".to_sym, new_state)
           self.save if options[:save]
         end
         

--- a/lib/stateflow/persistence/mongo_mapper.rb
+++ b/lib/stateflow/persistence/mongo_mapper.rb
@@ -12,7 +12,7 @@ module Stateflow
         end
 
         def save_to_persistence(new_state, options)
-          self.send(machine.state_column.to_sym, new_state)
+          self.send("#{machine.state_column}=".to_sym, new_state)
           self.save if options[:save]
         end
         

--- a/lib/stateflow/persistence/mongoid.rb
+++ b/lib/stateflow/persistence/mongoid.rb
@@ -12,7 +12,7 @@ module Stateflow
         end
 
         def save_to_persistence(new_state, options = {})
-          self.send(machine.state_column.to_sym, new_state)
+          self.send("#{machine.state_column}=".to_sym, new_state)
           self.save if options[:save]
         end
 


### PR DESCRIPTION
Fixes above-mentioned problem. This pull request also includes some whitespace corrections and DRYer specs around persistence.
