### PR TITLE
Removing deprecation warning

### DIFF
--- a/lib/stateflow/persistence/mongoid.rb
+++ b/lib/stateflow/persistence/mongoid.rb
@@ -2,8 +2,10 @@ module Stateflow
   module Persistence
     module Mongoid
       def self.install(base)
-        base.respond_to?(:before_validation_on_create) ? base.before_validation_on_create(:ensure_initial_state) : base.before_validation(:ensure_initial_state, :on => :create)
-        base.send :include, InstanceMethods
+        ActiveSupport::Deprecation.silence do
+          base.respond_to?(:before_validation_on_create) ? base.before_validation_on_create(:ensure_initial_state) : base.before_validation(:ensure_initial_state, :on => :create)
+          base.send :include, InstanceMethods
+        end
       end
 
       module InstanceMethods


### PR DESCRIPTION
Code to supress the deprecation warning when using the mongoid adapter with rails 3
