### PR TITLE
Just a shortcut method to machine.states.keys

### DIFF
--- a/lib/stateflow.rb
+++ b/lib/stateflow.rb
@@ -56,6 +56,10 @@ module Stateflow
       self.class.machine
     end
     
+    def available_states
+      machine.states.keys
+    end
+    
     private
     def fire_event(event_name, options = {})
       event = machine.events[event_name.to_sym]

--- a/spec/stateflow_spec.rb
+++ b/spec/stateflow_spec.rb
@@ -158,6 +158,10 @@ describe Stateflow do
     it "should respond to the current machine" do
       @r.should respond_to(:machine)
     end
+    
+    it "should respond to available states" do
+      @r.should respond_to(:available_states)
+    end
 
     it "should respond to load from persistence" do
       @r.should respond_to(:load_from_persistence)
@@ -346,5 +350,12 @@ describe Stateflow do
       stater.current_state == "bob"
     end
   end
+  
+  describe "available states" do
+    it "should return the available states" do
+      robot = Robot.new
+      robot.available_states.should include(:red, :yellow, :green)
+    end
+  end
+  
 end
-


### PR DESCRIPTION
It's useful to a better api implementation and it's more intuitive for developers.
