### PR TITLE
Remove deprecated ActiveSupport::Concern InstanceMethods.

### DIFF
--- a/lib/stateflow.rb
+++ b/lib/stateflow.rb
@@ -42,32 +42,30 @@ module Stateflow
     end
   end
   
-  module InstanceMethods
-    attr_accessor :_previous_state
-    
-    def current_state  
-      @current_state ||= load_from_persistence.nil? ? machine.initial_state : machine.states[load_from_persistence.to_sym]
-    end
-    
-    def set_current_state(new_state, options = {})
-      save_to_persistence(new_state.name.to_s, options)
-      @current_state = new_state
-    end
-    
-    def machine
-      self.class.machine
-    end
-    
-    def available_states
-      machine.states.keys
-    end
-    
-    private
-    def fire_event(event_name, options = {})
-      event = machine.events[event_name.to_sym]
-      raise Stateflow::NoEventFound.new("No event matches #{event_name}") if event.nil?
-      event.fire(current_state, self, options)
-    end
+  attr_accessor :_previous_state
+  
+  def current_state  
+    @current_state ||= load_from_persistence.nil? ? machine.initial_state : machine.states[load_from_persistence.to_sym]
+  end
+  
+  def set_current_state(new_state, options = {})
+    save_to_persistence(new_state.name.to_s, options)
+    @current_state = new_state
+  end
+  
+  def machine
+    self.class.machine
+  end
+  
+  def available_states
+    machine.states.keys
+  end
+  
+  private
+  def fire_event(event_name, options = {})
+    event = machine.events[event_name.to_sym]
+    raise Stateflow::NoEventFound.new("No event matches #{event_name}") if event.nil?
+    event.fire(current_state, self, options)
   end
   
   autoload :Machine, 'stateflow/machine'

--- a/lib/stateflow/persistence/active_record.rb
+++ b/lib/stateflow/persistence/active_record.rb
@@ -13,19 +13,17 @@ module Stateflow
         end
       end
       
-      module InstanceMethods
-        def load_from_persistence
-          send machine.state_column.to_sym
-        end
+      def load_from_persistence
+        send machine.state_column.to_sym
+      end
 
-        def save_to_persistence(new_state, options = {})
-          send("#{machine.state_column}=".to_sym, new_state)
-          save if options[:save]
-        end
-        
-        def ensure_initial_state
-          send("#{machine.state_column.to_s}=", current_state.name.to_s) if send(machine.state_column.to_s).blank?
-        end
+      def save_to_persistence(new_state, options = {})
+        send("#{machine.state_column}=".to_sym, new_state)
+        save if options[:save]
+      end
+      
+      def ensure_initial_state
+        send("#{machine.state_column.to_s}=", current_state.name.to_s) if send(machine.state_column.to_s).blank?
       end
     end
   end

--- a/lib/stateflow/persistence/mongo_mapper.rb
+++ b/lib/stateflow/persistence/mongo_mapper.rb
@@ -13,19 +13,17 @@ module Stateflow
         end
       end
 
-      module InstanceMethods
-        def load_from_persistence
-          send machine.state_column.to_sym
-        end
+      def load_from_persistence
+        send machine.state_column.to_sym
+      end
 
-        def save_to_persistence(new_state, options = {})
-          send("#{machine.state_column}=".to_sym, new_state)
-          save if options[:save]
-        end
-        
-        def ensure_initial_state
-          send("#{machine.state_column.to_s}=", current_state.name.to_s) if send(machine.state_column.to_s).blank?
-        end
+      def save_to_persistence(new_state, options = {})
+        send("#{machine.state_column}=".to_sym, new_state)
+        save if options[:save]
+      end
+      
+      def ensure_initial_state
+        send("#{machine.state_column.to_s}=", current_state.name.to_s) if send(machine.state_column.to_s).blank?
       end
     end
   end

--- a/lib/stateflow/persistence/mongoid.rb
+++ b/lib/stateflow/persistence/mongoid.rb
@@ -13,19 +13,17 @@ module Stateflow
         end
       end
       
-      module InstanceMethods
-        def load_from_persistence
-          send machine.state_column.to_sym
-        end
+      def load_from_persistence
+        send machine.state_column.to_sym
+      end
 
-        def save_to_persistence(new_state, options = {})
-          send("#{machine.state_column}=".to_sym, new_state)
-          save if options[:save]
-        end
+      def save_to_persistence(new_state, options = {})
+        send("#{machine.state_column}=".to_sym, new_state)
+        save if options[:save]
+      end
 
-        def ensure_initial_state
-          send("#{machine.state_column.to_s}=", current_state.name.to_s) if send(machine.state_column.to_s).blank?
-        end
+      def ensure_initial_state
+        send("#{machine.state_column.to_s}=", current_state.name.to_s) if send(machine.state_column.to_s).blank?
       end
     end
   end

--- a/lib/stateflow/persistence/none.rb
+++ b/lib/stateflow/persistence/none.rb
@@ -9,16 +9,14 @@ module Stateflow
         end
       end
 
-      module InstanceMethods
-        attr_accessor :state
-        
-        def load_from_persistence
-          @state
-        end
+      attr_accessor :state
+      
+      def load_from_persistence
+        @state
+      end
 
-        def save_to_persistence(new_state, options)
-          @state = new_state
-        end
+      def save_to_persistence(new_state, options)
+        @state = new_state
       end
     end
   end


### PR DESCRIPTION
Rails 3.2 is very whiny about InstanceMethods in ActiveSupport::Concern modules. This commit touched a lot of lines, but it's just removing the instance code from the wrapping InstanceMethods class.
