### PR TITLE
modify scope call to prevent deprecation warning in rails master

### DIFF
--- a/lib/stateflow/persistence/active_record.rb
+++ b/lib/stateflow/persistence/active_record.rb
@@ -9,7 +9,7 @@ module Stateflow
 
       module ClassMethods
         def add_scope(state)
-          scope state.name, where("#{machine.state_column}".to_sym => state.name.to_s)
+          scope state.name, -> { where("#{machine.state_column}".to_sym => state.name.to_s) }
         end
       end
 


### PR DESCRIPTION
In rails master, stateflow causes the following deprecation warning:

DEPRECATION WARNING: Using #scope without passing a callable object is deprecated. For example `scope :red, where(color: 'red')` should be changed to `scope :red, -> { where(color: 'red') }`. There are numerous gotchas in the former usage and it makes the implementation more complicated and buggy. (If you prefer, you can just define a class method named `self.red`.). (called from scope at /Users/adam/code/botornot/rails_server/vendor/bundle/ruby/1.9.1/bundler/gems/activerecord-deprecated_finders-fe150f26f009/lib/active_record/deprecated_finders/base.rb:71)

I fixed it.  
