### PR TITLE
Fix ActiveRecord deprecation warning from old-school scope usage.

### DIFF
--- a/lib/stateflow/persistence/active_record.rb
+++ b/lib/stateflow/persistence/active_record.rb
@@ -9,7 +9,7 @@ module Stateflow
 
       module ClassMethods
         def add_scope(state)
-          scope state.name, where("#{machine.state_column}".to_sym => state.name.to_s)
+          scope state.name, proc { where("#{machine.state_column}".to_sym => state.name.to_s) }
         end
       end
 


### PR DESCRIPTION
Removes annoying deprecation warnings from Rails output:

```
DEPRECATION WARNING: Using #scope without passing a callable object is deprecated. For example `scope :red, where(color: 'red')` should be changed to `scope :red, -> { where(color: 'red') }`. There are numerous gotchas in the former usage and it makes the implementation more complicated and buggy. (If you prefer, you can just define a class method named `self.red`.). (called from add_scope at /Users/jnh/.rvm/gems/ruby-2.0.0-p247/bundler/gems/stateflow-dbc47eed5c77/lib/stateflow/persistence/active_record.rb:12)
```
