### PR TITLE
Add before and after event callbacks.

### DIFF
--- a/lib/stateflow/event.rb
+++ b/lib/stateflow/event.rb
@@ -19,11 +19,13 @@ module Stateflow
       new_state = klass.machine.states[transition.find_to_state(klass)]
       no_state_found(transition.to) if new_state.nil?
 
-      current_state.execute_action(:exit, klass)
+      current_state.execute_action(:before_exit, klass)
       klass._previous_state = current_state.name.to_s
-      new_state.execute_action(:enter, klass)
+      current_state.execute_action(:after_exit, klass)
 
+      new_state.execute_action(:before_enter, klass)
       klass.set_current_state(new_state, options)
+      new_state.execute_action(:after_enter, klass)
       true
     end
 

--- a/lib/stateflow/persistence/active_record.rb
+++ b/lib/stateflow/persistence/active_record.rb
@@ -9,7 +9,7 @@ module Stateflow
 
       module ClassMethods
         def add_scope(state)
-          scope state.name, where("#{machine.state_column}".to_sym => state.name.to_s)
+          scope state.name, proc { where("#{machine.state_column}".to_sym => state.name.to_s) }
         end
       end
 

--- a/lib/stateflow/state.rb
+++ b/lib/stateflow/state.rb
@@ -9,14 +9,6 @@ module Stateflow
       instance_eval(&options) if block_given?
     end
 
-    def enter(method = nil, &block)
-      @options[:enter] = method.nil? ? block : method
-    end
-
-    def exit(method = nil, &block)
-      @options[:exit] = method.nil? ? block : method
-    end
-
     def execute_action(action, base)
       action = @options[action.to_sym]
 
@@ -26,6 +18,24 @@ module Stateflow
       when Proc
         action.call(base)
       end
+    end
+
+    def before_enter(method=nil,&block)
+      @options[:before_enter] = method || block
+    end
+    alias enter before_enter
+
+    def after_enter(method=nil,&block)
+      @options[:after_enter]  = method || block
+    end
+
+    def before_exit(method=nil,&block)
+      @options[:before_exit]  = method || block
+    end
+    alias exit before_exit
+
+    def after_exit(method=nil,&block)
+      @options[:after_exit]   = method || block
     end
   end
 end

--- a/lib/stateflow/transition.rb
+++ b/lib/stateflow/transition.rb
@@ -1,31 +1,31 @@
 module Stateflow
   class IncorrectTransition < Exception; end
-  
+
   class Transition
     attr_reader :from, :to, :if, :decide
-    
+
     def initialize(args)
       @from = [args[:from]].flatten
       @to = args[:to]
       @if = args[:if]
       @decide = args[:decide]
-    end 
-    
+    end
+
     def can_transition?(base)
       return true unless @if
       execute_action(@if, base)
     end
-    
+
     def find_to_state(base)
       raise IncorrectTransition.new("Array of destinations and no decision") if @to.is_a?(Array) && @decide.nil?
       return @to unless @to.is_a?(Array)
-      
+
       to = execute_action(@decide, base)
-      
+
       raise NoStateFound.new("Decision did not return a state that was set in the 'to' argument") unless @to.include?(to)
       to
     end
-      
+
     private
     def execute_action(action, base)
       case action


### PR DESCRIPTION
Add before and after event callbacks.

 - Rename `enter` and `exit` to `before_enter` and `before_exit`.
 - Alias `enter` to `before_enter`.
 - Alias `exit` to `before_exit`.
 - Modify transition to call before and after callbacks.