### PR TITLE
Do not create scope when conflicting method exists

### DIFF
--- a/lib/stateflow/persistence/mongoid.rb
+++ b/lib/stateflow/persistence/mongoid.rb
@@ -9,7 +9,7 @@ module Stateflow
 
       module ClassMethods
         def add_scope(state)
-          scope state.name, -> { where(:state => state.name.to_s) }
+          scope state.name, -> { where(:state => state.name.to_s) } unless self.respond_to?(state.name)
         end
       end
 


### PR DESCRIPTION
This allows i.e. to use a finite state machine with a status "new".